### PR TITLE
Moz: Extend Backlinks functionality

### DIFF
--- a/Moz.xml
+++ b/Moz.xml
@@ -271,6 +271,8 @@
         <JsonPath Expr="lf" Title="Link/Meta No Follow" Id="lf-2048" Converter="Bool" Converter.TrueIfBit="2048" Tag="Link:2" HelpText="The link appeared on a page using a page-level (meta) nofollow directive. This link passes no juice."/>
         <JsonPath Expr="lf" Title="Link/Same Root Domain" Id="lf-4096" Converter="Bool" Converter.TrueIfBit="4096" Tag="Link:2" HelpText="The link is between two pages on the same root domain. The link is internal, and strongly indicates an administrative relationship between the two pages."/>
         <JsonPath Expr="lf" Title="Link/Rel Canonical" Id="lf-32768" Converter="Bool" Converter.TrueIfBit="32768" Tag="Link:2" HelpText="The link indicates a canonical form of the page using the rel=canonical directive ."/>
+        <JsonPath Expr="lt" Title="Link/Anchor Text" Id="lt" Converter="String" Tag="Link:4" HelpText="The anchor text of the link, including any markup (for example, image tags with alt text)."/>
+        <JsonPath Expr="lnt" Title="Link/Normalized Anchor Text" Id="lnt" Converter="String" Tag="Link:8" HelpText="The anchor text of the link, excluding markup."/>
         <!--<JsonPath Expr="lf" Title="[Flags]" Id="lf" Tag="Link:2"/>-->
         <!-- //LINK -->
 


### PR DESCRIPTION
I have added in two additional links columns into the Backlinks section. These columns will pull anchor text, with bit flag Link:4 fetching anchor text with markup, and bit flag Link:8 fetching anchor text excluding markup (As described in the documentation https://moz.com/help/links-api/making-calls/link-metrics).